### PR TITLE
Refactor ansible playbooks

### DIFF
--- a/ansible/playbooks/common/mount-shared.yaml
+++ b/ansible/playbooks/common/mount-shared.yaml
@@ -1,0 +1,15 @@
+- name: Create /mnt/shared directory
+  file:
+    path: /mnt/shared
+    state: directory
+    mode: '0755'
+
+- name: Mount NFS share(shared)
+  mount:
+    path: /mnt/shared
+    src: "{{ nfs_server }}:{{ nfs_shared_path }}"
+    fstype: nfs
+    opts: defaults
+    state: mounted
+    fstab: yes
+

--- a/ansible/playbooks/common/setup-github.yaml
+++ b/ansible/playbooks/common/setup-github.yaml
@@ -1,0 +1,16 @@
+- name: Create ~/.ssh directory for user
+  file:
+    path: "/home/{{ user_name }}/.ssh"
+    state: directory
+    mode: '0700'
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
+
+- name: Symlink GitHub key
+  file:
+    src: /mnt/shared/secrets/keys/github
+    dest: "/home/{{ user_name }}/.ssh/github"
+    state: link
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"
+

--- a/ansible/playbooks/install-neovim.yaml
+++ b/ansible/playbooks/install-neovim.yaml
@@ -13,36 +13,9 @@
         name: neovim
         state: present
 
-    - name: Create /mnt/shared directory
-      file:
-        path: /mnt/shared
-        state: directory
-        mode: '0755'
+    - import_tasks: common/mount-shared.yaml
 
-    - name: Mount NFS share(shared)
-      mount:
-        path: /mnt/shared
-        src: "{{ nfs_server }}:{{ nfs_shared_path }}"
-        fstype: nfs
-        opts: defaults
-        state: mounted
-        fstab: yes
-
-    - name: Create ~/.ssh directory for user chiyonn
-      file:
-        path: "/home/{{ user_name }}/.ssh"
-        state: directory
-        mode: '0700'
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
-
-    - name: Symlink GitHub key
-      file:
-        src: /mnt/shared/secrets/keys/github
-        dest: "/home/{{ user_name }}/.ssh/github"
-        state: link
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
+    - import_tasks: common/setup-github.yaml
 
     - name: Create ~/.config directory for user chiyonn
       file:

--- a/ansible/playbooks/setup-fappom.yaml
+++ b/ansible/playbooks/setup-fappom.yaml
@@ -28,35 +28,9 @@
         opts: defaults
         state: mounted
 
-    - name: Create /mnt/shared directory
-      file:
-        path: /mnt/shared
-        state: directory
-        mode: '0755'
+    - import_tasks: common/mount-shared.yaml
 
-    - name: Mount NFS share(shared)
-      mount:
-        path: /mnt/shared
-        src: "{{ nfs_server }}:{{ nfs_shared_path }}"
-        fstype: nfs
-        opts: defaults
-        state: mounted
-
-    - name: Create ~/.ssh directory for user chiyonn
-      file:
-        path: "/home/{{ user_name }}/.ssh"
-        state: directory
-        mode: '0700'
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
-
-    - name: Symlink GitHub key
-      file:
-        src: /mnt/shared/secrets/keys/github
-        dest: "/home/{{ user_name }}/.ssh/github"
-        state: link
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
+    - import_tasks: common/setup-github.yaml
 
     - name: Git clone fappom repository
       git:

--- a/ansible/playbooks/setup-silverbullet.yaml
+++ b/ansible/playbooks/setup-silverbullet.yaml
@@ -28,35 +28,9 @@
         opts: defaults
         state: mounted
 
-    - name: Create /mnt/shared directory
-      file:
-        path: /mnt/shared
-        state: directory
-        mode: '0755'
+    - import_tasks: common/mount-shared.yaml
 
-    - name: Mount NFS share(shared)
-      mount:
-        path: /mnt/shared
-        src: "{{ nfs_server }}:{{ nfs_shared_path }}"
-        fstype: nfs
-        opts: defaults
-        state: mounted
-
-    - name: Create ~/.ssh directory for user chiyonn
-      file:
-        path: "/home/{{ user_name }}/.ssh"
-        state: directory
-        mode: '0700'
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
-
-    - name: Symlink GitHub key
-      file:
-        src: /mnt/shared/secrets/keys/github
-        dest: "/home/{{ user_name }}/.ssh/github"
-        state: link
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
+    - import_tasks: common/setup-github.yaml
 
     - name: Git clone silverbullet repository
       git:


### PR DESCRIPTION
## Summary
- deduplicate mount/share steps into `common/mount-shared.yaml`
- deduplicate github SSH setup into `common/setup-github.yaml`
- reuse these new files from existing playbooks

## Testing
- `ansible-playbook --syntax-check ansible/playbooks/install-neovim.yaml` *(fails: command not found)*
- `ansible-playbook --syntax-check ansible/playbooks/setup-fappom.yaml` *(fails: command not found)*
- `ansible-playbook --syntax-check ansible/playbooks/setup-silverbullet.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f7f7e09c8332b57219c3f1744319