### PR TITLE
Refactor Ansible layout with roles

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -2,25 +2,22 @@
 
 ### 1. 必要なロールのインストール
 
-以下のコマンドでDockerインストール用のAnsibleロールを取得。
+Docker 環境を構築するために [geerlingguy.docker](https://galaxy.ansible.com/geerlingguy/docker) ロールを利用します。
 
-```
+```bash
 ansible-galaxy install geerlingguy.docker -p ansible/roles
 ```
 
-### 2. Playbookの実行
+### 2. Playbook の実行
 
-Docker のインストールと Silverbullet 用の設定を行う 2 つの Playbook が
-含まれています。
+各ホストのセットアップは `playbooks/` 配下の Playbook から実行します。
 
-```
-# Docker インストール
+```bash
+# Docker のインストール
 ansible-playbook -i inventory/hosts.ini playbooks/install-docker.yaml
 
-# Silverbullet ボリュームのマウント
-ansible-playbook -i inventory/hosts.ini playbooks/mount-silverbullet-volume.yaml
+# fappom ホストのセットアップ
+ansible-playbook -i inventory/hosts.ini playbooks/setup-fappom.yaml
 ```
 
-`mount-silverbullet-volume.yaml` では `nfs_server` や `user_name`
-などの変数を必要に応じて変更してください。
-
+必要に応じて `inventory/hosts.ini` 内の変数や Playbook の変数を調整してください。

--- a/ansible/playbooks/install-docker.yaml
+++ b/ansible/playbooks/install-docker.yaml
@@ -2,14 +2,4 @@
   hosts: docker_hosts
   become: yes
   roles:
-    - geerlingguy.docker
-
-- name: Add user to docker group
-  hosts: docker_hosts
-  become: yes
-  tasks:
-    - name: Add user 'chiyonn' to docker group
-      user:
-        name: chiyonn
-        groups: docker
-        append: yes
+    - docker

--- a/ansible/playbooks/install-neovim.yaml
+++ b/ansible/playbooks/install-neovim.yaml
@@ -6,16 +6,13 @@
     nfs_server: 192.168.40.3
     nfs_silverbullet_path: /volume1/silverbullet
     nfs_shared_path: /volume1/shared
+  roles:
+    - common
   tasks:
-
     - name: Install neovim
       apt:
         name: neovim
         state: present
-
-    - import_tasks: common/mount-shared.yaml
-
-    - import_tasks: common/setup-github.yaml
 
     - name: Create ~/.config directory for user chiyonn
       file:

--- a/ansible/playbooks/setup-fappom.yaml
+++ b/ansible/playbooks/setup-fappom.yaml
@@ -6,47 +6,7 @@
     nfs_server: 192.168.40.3
     nfs_fappom_path: /volume1/fappom
     nfs_shared_path: /volume1/shared
-  tasks:
-
-    - name: Install nfs-common package
-      apt:
-        name: nfs-common
-        state: present
-        update_cache: yes
-
-    - name: Create mount directory
-      file:
-        path: /mnt/fappom
-        state: directory
-        mode: '0755'
-
-    - name: Mount NFS share(fappom)
-      mount:
-        path: /mnt/fappom
-        src: "{{ nfs_server }}:{{ nfs_fappom_path }}"
-        fstype: nfs
-        opts: defaults
-        state: mounted
-
-    - import_tasks: common/mount-shared.yaml
-
-    - import_tasks: common/setup-github.yaml
-
-    - name: Git clone fappom repository
-      git:
-        repo: git@github.com:chiyonn/fappom.git
-        dest: "/home/{{ user_name }}/fappom"
-        key_file: "/home/{{ user_name }}/.ssh/github"
-        accept_hostkey: yes
-        version: main
-      become: false
-      vars:
-        ansible_ssh_private_key_file: "/home/{{ user_name }}/.ssh/github"
-
-    - name: Symlink env file
-      file:
-        src: /mnt/shared/secrets/envs/fappom.dev.env
-        dest: "/home/{{ user_name }}/fappom/.env"
-        state: link
-        owner: "{{ user_name }}"
-        group: "{{ user_name }}"
+  roles:
+    - common
+    - docker
+    - fappom

--- a/ansible/playbooks/setup-silverbullet.yaml
+++ b/ansible/playbooks/setup-silverbullet.yaml
@@ -6,8 +6,9 @@
     nfs_server: 192.168.40.3
     nfs_silverbullet_path: /volume1/silverbullet
     nfs_shared_path: /volume1/shared
+  roles:
+    - common
   tasks:
-
     - name: Install nfs-common package
       apt:
         name: nfs-common
@@ -27,10 +28,6 @@
         fstype: nfs
         opts: defaults
         state: mounted
-
-    - import_tasks: common/mount-shared.yaml
-
-    - import_tasks: common/setup-github.yaml
 
     - name: Git clone silverbullet repository
       git:

--- a/ansible/roles/common/tasks/main.yaml
+++ b/ansible/roles/common/tasks/main.yaml
@@ -1,0 +1,2 @@
+- import_tasks: mount-shared.yaml
+- import_tasks: setup-github.yaml

--- a/ansible/roles/common/tasks/mount-shared.yaml
+++ b/ansible/roles/common/tasks/mount-shared.yaml
@@ -12,4 +12,3 @@
     opts: defaults
     state: mounted
     fstab: yes
-

--- a/ansible/roles/common/tasks/setup-github.yaml
+++ b/ansible/roles/common/tasks/setup-github.yaml
@@ -13,4 +13,3 @@
     state: link
     owner: "{{ user_name }}"
     group: "{{ user_name }}"
-

--- a/ansible/roles/docker/defaults/main.yaml
+++ b/ansible/roles/docker/defaults/main.yaml
@@ -1,0 +1,1 @@
+docker_user: chiyonn

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,0 +1,9 @@
+- name: Install Docker using geerlingguy.docker role
+  import_role:
+    name: geerlingguy.docker
+
+- name: Add user to docker group
+  user:
+    name: "{{ docker_user }}"
+    groups: docker
+    append: yes

--- a/ansible/roles/fappom/tasks/main.yaml
+++ b/ansible/roles/fappom/tasks/main.yaml
@@ -1,0 +1,38 @@
+- name: Install nfs-common package
+  apt:
+    name: nfs-common
+    state: present
+    update_cache: yes
+
+- name: Create mount directory
+  file:
+    path: /mnt/fappom
+    state: directory
+    mode: '0755'
+
+- name: Mount NFS share(fappom)
+  mount:
+    path: /mnt/fappom
+    src: "{{ nfs_server }}:{{ nfs_fappom_path }}"
+    fstype: nfs
+    opts: defaults
+    state: mounted
+
+- name: Git clone fappom repository
+  git:
+    repo: git@github.com:chiyonn/fappom.git
+    dest: "/home/{{ user_name }}/fappom"
+    key_file: "/home/{{ user_name }}/.ssh/github"
+    accept_hostkey: yes
+    version: main
+  become: false
+  vars:
+    ansible_ssh_private_key_file: "/home/{{ user_name }}/.ssh/github"
+
+- name: Symlink env file
+  file:
+    src: /mnt/shared/secrets/envs/fappom.dev.env
+    dest: "/home/{{ user_name }}/fappom/.env"
+    state: link
+    owner: "{{ user_name }}"
+    group: "{{ user_name }}"


### PR DESCRIPTION
## Summary
- organize playbooks to use roles
- add `common`, `docker`, and `fappom` roles
- update existing playbooks to use the new roles
- refresh Ansible README

## Testing
- `ansible-playbook --syntax-check ansible/playbooks/setup-fappom.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68671cf42c908332b94cd9db323fd405